### PR TITLE
Support greeks and POST GetQuotes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/timpalpant/go-tradier
 
+go 1.15
+
 require (
 	github.com/cenkalti/backoff v2.0.0+incompatible
 	github.com/pkg/errors v0.8.0

--- a/interface.go
+++ b/interface.go
@@ -141,6 +141,19 @@ type Quote struct {
 	ExpirationType   string   `json:"expiration_type"`
 	OptionType       string   `json:"option_type"`
 	RootSymbol       string   `json:"root_symbol"`
+	Greeks           Greeks
+}
+
+type Greeks struct {
+	Delta  float64
+	Gamma  float64
+	Theta  float64
+	Vega   float64
+	Rho    float64
+	BidIV  float64 `json:"bid_iv"`
+	MidIV  float64 `json:"mid_iv"`
+	AskIV  float64 `json:"ask_iv"`
+	SmvVol float64 `json:"smv_vol"`
 }
 
 type TimeSale struct {


### PR DESCRIPTION
Hi - not sure if you're taking updates on this project but I found it useful.

This PR adds support for Greeks on Options and updates GetQuotes() to use the POST API to support larger numbers of quotes per call.  It maxes out around 7K option symbols before there is a body size error from upstream.  It is on the user to chunk requests if they hit that limit.